### PR TITLE
Fixed error showing table with string enum types.

### DIFF
--- a/whetlab.m
+++ b/whetlab.m
@@ -941,7 +941,7 @@ classdef whetlab
         for i = 1:numel(ids)
             params = loadjson(self.ids_to_param_values.get(ids(i)));
             for j = 1:numel(param_names)
-                row(j) = params.(param_names{j});
+                row{j} = params.(param_names{j});
             end
             param_vals = [param_vals; [row, y(i)]];
         end


### PR DESCRIPTION
I had activation function as enum parameter with values "tanh", "sigm", "relu". When I tried to plot the report with `scientist.report()` the graph was plotted correctly, but table gave an error "Subscripted assignment dimension mismatch.". I traced this down to simple change in the code and now it works correctly for me. 

Table design is worth improvement though, it should cover the whole figure area and I was missing sorting functionality. UITable didn't seem to have property to enable sorting, so it is not as straightforward as it seems. Maybe on other day I have more time to figure out Matlab UI quirks.